### PR TITLE
Improve error message for missing compile-time endif

### DIFF
--- a/src/compiler/parse_stmt.c
+++ b/src/compiler/parse_stmt.c
@@ -1024,15 +1024,20 @@ static inline Ast *parse_var_stmt(ParseContext *c)
 
 static inline bool parse_ct_compound_stmt(ParseContext *c, AstId *start)
 {
-	AstId *next = start;
-	while (1)
-	{
-		TokenType tok = c->tok;
-		if (tok == TOKEN_CT_ELSE || tok == TOKEN_CT_ENDIF) break;
-		ASSIGN_AST_OR_RET(Ast *stmt, parse_stmt(c), false);
-		ast_append(&next, stmt);
-	}
-	return true;
+        AstId *next = start;
+        while (1)
+        {
+                TokenType tok = c->tok;
+                if (tok == TOKEN_CT_ELSE || tok == TOKEN_CT_ENDIF) break;
+                if (tok == TOKEN_RBRACE || tok == TOKEN_EOF)
+                {
+                        PRINT_ERROR_HERE("Expected '$endif'.");
+                        return false;
+                }
+                ASSIGN_AST_OR_RET(Ast *stmt, parse_stmt(c), false);
+                ast_append(&next, stmt);
+        }
+        return true;
 }
 
 

--- a/test/test_suite/compile_time/ct_if_missing_endif.c3
+++ b/test/test_suite/compile_time/ct_if_missing_endif.c3
@@ -1,0 +1,7 @@
+fn void main()
+{
+    $if true:
+        int x = 0;
+    $else
+        int y = 1;
+} // #error: Expected '$endif'


### PR DESCRIPTION
## Summary
- report missing `$endif` when a compile-time conditional block is left open
- add regression test for missing `$endif`

## Testing
- `cmake -B build -S .` *(fails: Could not find LLD_COFF)*

------
https://chatgpt.com/codex/tasks/task_e_6899b4d69dc4832e903bff55e850917a